### PR TITLE
Tweak lower bound on base

### DIFF
--- a/validity/validity.cabal
+++ b/validity/validity.cabal
@@ -25,7 +25,7 @@ library
   hs-source-dirs:      src
   exposed-modules:     Data.Validity
                      , Data.RelativeValidity
-  build-depends:       base >= 4 && < 5
+  build-depends:       base >= 4.8 && < 5
   default-language:    Haskell2010
 
 source-repository head


### PR DESCRIPTION
As currently, `validity` runs into a compile error with base-4.7 and older:

```
Configuring component lib from validity-0.3.0.4
Preprocessing library validity-0.3.0.4...
[1 of 2] Compiling Data.RelativeValidity ( src/Data/RelativeValidity.hs, /tmp/matrix-worker/1482618943/dist-newstyle/build/x86_64-linux/ghc-7.8.4/validity-0.3.0.4/build/Data/RelativeValidity.o )
[2 of 2] Compiling Data.Validity    ( src/Data/Validity.hs, /tmp/matrix-worker/1482618943/dist-newstyle/build/x86_64-linux/ghc-7.8.4/validity-0.3.0.4/build/Data/Validity.o )

src/Data/Validity.hs:93:19:
    Not in scope: type constructor or class ‘Word’
```