### PR TITLE
Fix incorrect lower bound

### DIFF
--- a/genvalidity/genvalidity.cabal
+++ b/genvalidity/genvalidity.cabal
@@ -31,7 +31,7 @@ library
         Data.GenRelativeValidity
     build-depends:
         base >= 4.7 && <5,
-        validity >=0.3 && <0.4,
+        validity >=0.3.3 && <0.4,
         QuickCheck >=2.7 && <2.10
     default-language: Haskell2010
     hs-source-dirs: src


### PR DESCRIPTION
This should address #6

Note: there is no need to upload a new release because I've already revised the meta-data on
Hackage (see https://hackage.haskell.org/package/genvalidity-0.3.2.0/revisions/) accordingly.