### PR TITLE
Fix inaccurate version bound

### DIFF
--- a/validity-time/validity-time.cabal
+++ b/validity-time/validity-time.cabal
@@ -26,7 +26,7 @@ library
         Data.Validity.Time.LocalTime
     build-depends:
         base >= 4.7 && <5,
-        validity -any,
+        validity >= 0.3.2 && < 0.4,
         time -any
     default-language: Haskell2010
     hs-source-dirs: src


### PR DESCRIPTION
This prevents cabal running into the compile error below:

```
Configuring library for validity-time-0.0.0.1..
Preprocessing library for validity-time-0.0.0.1..
Building library for validity-time-0.0.0.1..
[1 of 5] Compiling Data.Validity.Time.Calendar ( src/Data/Validity/Time/Calendar.hs, /tmp/validity-time-0.0.0.1/dist-newstyle/build/x86_64-linux/ghc-8.0.2/validity-time-0.0.0.1/build/Data/Validity/Time/Calendar.o ) [Data.Validity changed]
[2 of 5] Compiling Data.Validity.Time.Clock ( src/Data/Validity/Time/Clock.hs, /tmp/validity-time-0.0.0.1/dist-newstyle/build/x86_64-linux/ghc-8.0.2/validity-time-0.0.0.1/build/Data/Validity/Time/Clock.o ) [Data.Validity changed]

src/Data/Validity/Time/Clock.hs:13:33: error:
    • No instance for (Validity Rational)
        arising from a use of ‘isValid’
    • In the expression: isValid i
      In an equation for ‘isValid’: isValid (ModJulianDate i) = isValid i
      In the instance declaration for ‘Validity UniversalTime’
```