### PR TITLE
Use custom mapSpecTree for compatibility w/ new hspec

### DIFF
--- a/genvalidity-hspec/package.yaml
+++ b/genvalidity-hspec/package.yaml
@@ -47,6 +47,7 @@ library:
   - genvalidity >=0.5
   - genvalidity-property >=0.2
   - hspec
+  - transformers
   - validity >=0.5
 
 tests:


### PR DESCRIPTION
Addresses https://github.com/NorfairKing/validity/issues/32

This seems to work with both new and old versions of hspec. I did some light testing with the following custom `stack.yaml` files:

```yaml
# uses hspec 2.5.2
resolver: nightly-2018-07-05
```

```yaml
resolver: nightly-2018-07-05
extra-deps:
- hspec-2.5.4
- hspec-core-2.5.4
- hspec-discover-2.5.4
```