### PR TITLE
Shuffle sizes for generating lists

### DIFF
--- a/genvalidity/CHANGELOG.md
+++ b/genvalidity/CHANGELOG.md
@@ -1,2 +1,3 @@
 Unreleased changes:
 * -0 is now a valid value for Double and Float.
+* arbPartition now shuffles the partitions, which means that genListOf produces lists of elements with shuffled sizes. This also fixes the same problem with `instance GenUnchecked a => GenUnchecked [a]`.

--- a/genvalidity/src/Data/GenValidity.hs
+++ b/genvalidity/src/Data/GenValidity.hs
@@ -610,12 +610,14 @@ genSplit5 n
 
 -- | 'arbPartition n' generates a list 'ls' such that 'sum ls' equals 'n'.
 arbPartition :: Int -> Gen [Int]
-arbPartition k
-    | k <= 0 = pure []
-    | otherwise = do
-        first <- choose (1, k)
-        rest <- arbPartition $ k - first
-        return $ first : rest
+arbPartition i = go i >>= shuffle
+  where
+    go k
+      | k <= 0 = pure []
+      | otherwise = do
+          first <- choose (1, k)
+          rest <- arbPartition $ k - first
+          return $ first : rest
 
 -- | A version of @listOf@ that takes size into account more accurately.
 genListOf :: Gen a -> Gen [a]

--- a/genvalidity/src/Data/GenValidity.hs
+++ b/genvalidity/src/Data/GenValidity.hs
@@ -81,6 +81,11 @@ import GHC.Real (Ratio(..))
 
 import Test.QuickCheck hiding (Fixed)
 
+#if !MIN_VERSION_QuickCheck(2,8,0)
+import Data.List (sortBy)
+import Data.Ord (comparing)
+#endif
+
 #if MIN_VERSION_base(4,8,0)
 import GHC.Natural
 import Control.Monad (forM)
@@ -618,6 +623,14 @@ arbPartition i = go i >>= shuffle
           first <- choose (1, k)
           rest <- arbPartition $ k - first
           return $ first : rest
+
+#if !MIN_VERSION_QuickCheck(2,8,0)
+-- | Generates a random permutation of the given list.
+shuffle :: [a] -> Gen [a]
+shuffle xs = do
+  ns <- vectorOf (length xs) (choose (minBound :: Int, maxBound))
+  return (map snd (sortBy (comparing fst) (zip ns xs)))
+#endif
 
 -- | A version of @listOf@ that takes size into account more accurately.
 genListOf :: Gen a -> Gen [a]


### PR DESCRIPTION
`arbPartition` now shuffles the partitions, which means that `genListOf` produces lists of elements with shuffled sizes. This also fixes the same problem with `instance GenUnchecked a => GenUnchecked [a]`.