### PR TITLE
Add properties exercising min/max to ordSpec

### DIFF
--- a/genvalidity-hspec/src/Test/Validity/Ord.hs
+++ b/genvalidity-hspec/src/Test/Validity/Ord.hs
@@ -111,6 +111,7 @@ ordSpecOnGen gen genname s =
             fungestr = geTypeStr @a
             funltstr = ltTypeStr @a
             fungtstr = gtTypeStr @a
+            minmaxtstr = genDescr @(a->a->a)
             cmple = (<=) @a
             cmpge = (>=) @a
             cmplt = (<) @a
@@ -221,3 +222,19 @@ ordSpecOnGen gen genname s =
                          , name ++ "\"" ++ "'s"
                          ]) $
                     equivalentOnGens2 cmpgt (\a b -> compare a b == GT) gen2 s2
+            describe (minmaxtstr "min") $ do
+                it
+                    (unwords
+                         [ "is equivalent to (\\a b -> if a <= b then a else b) for"
+                         , "\"" ++ genname
+                         , name ++ "\"" ++ "'s"
+                         ]) $
+                    equivalentOnGens2 min (\a b -> if a <= b then a else b) gen2 s2
+            describe (minmaxtstr "max") $ do
+                it
+                    (unwords
+                         [ "is equivalent to (\\a b -> if a >= b then a else b) for"
+                         , "\"" ++ genname
+                         , name ++ "\"" ++ "'s"
+                         ]) $
+                    equivalentOnGens2 max (\a b -> if a >= b then a else b) gen2 s2

--- a/genvalidity-hspec/src/Test/Validity/Ord.hs
+++ b/genvalidity-hspec/src/Test/Validity/Ord.hs
@@ -112,6 +112,11 @@ ordSpecOnGen gen genname s =
             funltstr = ltTypeStr @a
             fungtstr = gtTypeStr @a
             minmaxtstr = genDescr @(a->a->a)
+            itProp s = it $ unwords
+                [ s
+                  , "\"" ++ genname
+                  , name ++ "\"" ++ "'s"
+                ]
             cmple = (<=) @a
             cmpge = (>=) @a
             cmplt = (<) @a
@@ -121,120 +126,40 @@ ordSpecOnGen gen genname s =
             s2 = shrinkT2 s
         describe ("Ord " ++ name) $ do
             describe funlestr $ do
-                it
-                    (unwords
-                         [ "is reflexive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is reflexive for" $
                     reflexivityOnGen cmple gen s
-                it
-                    (unwords
-                         [ "is antisymmetric for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is antisymmetric for" $
                     antisymmetryOnGens cmple gen2 s
-                it
-                    (unwords
-                         [ "is transitive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is transitive for" $
                     transitivityOnGens cmple gen3 s
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> compare a b /= GT) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> compare a b /= GT) for" $
                     equivalentOnGens2 cmple (\a b -> compare a b /= GT) gen2 s2
             describe fungestr $ do
-                it
-                    (unwords
-                         [ "is reflexive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is reflexive for" $
                     reflexivityOnGen cmpge gen s
-                it
-                    (unwords
-                         [ "is antisymmetric for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is antisymmetric for" $
                     antisymmetryOnGens cmpge gen2 s
-                it
-                    (unwords
-                         [ "is transitive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is transitive for" $
                     transitivityOnGens cmpge gen3 s
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> compare a b /= LT) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> compare a b /= LT) for" $
                     equivalentOnGens2 cmpge (\a b -> compare a b /= LT) gen2 s2
             describe funltstr $ do
-                it
-                    (unwords
-                         [ "is antireflexive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is antireflexive for" $
                     antireflexivityOnGen cmplt gen s
-                it
-                    (unwords
-                         [ "is transitive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is transitive for" $
                     transitivityOnGens cmplt gen3 s
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> compare a b == LT) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> compare a b == LT) for" $
                     equivalentOnGens2 cmplt (\a b -> compare a b == LT) gen2 s2
             describe fungtstr $ do
-                it
-                    (unwords
-                         [ "is antireflexive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is antireflexive for" $
                     antireflexivityOnGen cmpgt gen s
-                it
-                    (unwords
-                         [ "is transitive for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is transitive for" $
                     transitivityOnGens cmpgt gen3 s
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> compare a b == GT) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> compare a b == GT) for" $
                     equivalentOnGens2 cmpgt (\a b -> compare a b == GT) gen2 s2
             describe (minmaxtstr "min") $ do
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> if a <= b then a else b) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> if a <= b then a else b) for" $
                     equivalentOnGens2 min (\a b -> if a <= b then a else b) gen2 s2
             describe (minmaxtstr "max") $ do
-                it
-                    (unwords
-                         [ "is equivalent to (\\a b -> if a >= b then a else b) for"
-                         , "\"" ++ genname
-                         , name ++ "\"" ++ "'s"
-                         ]) $
+                itProp "is equivalent to (\\a b -> if a >= b then a else b) for" $
                     equivalentOnGens2 max (\a b -> if a >= b then a else b) gen2 s2


### PR DESCRIPTION
I noticed that ordSpec wasn't getting me 100% coverage of a derived Ord instance. Adding tests for the min/max functions seemed to make the difference.

(I realize it may be a bit silly to insist that every scrap of yellow- or red-highlighted code gets banished from my coverage reports, but this library seems to be targeted for scratching that and similar completionist itches!)

While I was messing with that module, I tried reducing some of the noise around generating spec names for those properties, so the net line count of this PR could be negative. :) Thanks!