### PR TITLE
validity: Don't overflow Int/Word sizes

### DIFF
--- a/validity/src/Data/Validity.hs
+++ b/validity/src/Data/Validity.hs
@@ -99,14 +99,14 @@ import Data.Bits ((.&.))
 import Data.Char (ord)
 import Data.Int (Int64)
 import GHC.Int (Int8(..), Int16(..), Int32(..))
-import GHC.Exts (Char(..), ord#, isTrue#, (<=#), (>=#), (<#), (>=#))
+import GHC.Exts (Char(..), ord#, isTrue#, (<=#), (>=#), (>=#))
 #if MIN_VERSION_base(4,8,0)
 import GHC.Word (Word8(..), Word16(..), Word32(..), Word64(..))
 #else
 import Data.Word (Word)
 import GHC.Word (Word8(..), Word16(..), Word32(..), Word64(..))
 #endif
-import GHC.Exts (ltWord#)
+import GHC.Exts (leWord#)
 import GHC.Generics
 #if MIN_VERSION_base(4,8,0)
 import GHC.Natural
@@ -422,7 +422,7 @@ instance Validity Int where
 instance Validity Int8 where
     validate (I8# i#) =
       mconcat
-        [ declare "The contained integer is smaller than 2^7 = 128" $ isTrue# (i# <# 128#)
+        [ declare "The contained integer is smaller than 2^7 = 128" $ isTrue# (i# <=# 127#)
         , declare "The contained integer is greater than or equal to -2^7 = -128" $ isTrue# (i# >=# -128#)
         ]
 
@@ -430,7 +430,7 @@ instance Validity Int8 where
 instance Validity Int16 where
     validate (I16# i#) =
       mconcat
-        [ declare "The contained integer is smaller than 2^15 = 32768" $ isTrue# (i# <# 32768#)
+        [ declare "The contained integer is smaller than 2^15 = 32768" $ isTrue# (i# <=# 32767#)
         , declare "The contained integer is greater than or equal to -2^15 = -32768" $ isTrue# (i# >=# -32768#)
         ]
 
@@ -438,7 +438,7 @@ instance Validity Int16 where
 instance Validity Int32 where
     validate (I32# i#) =
       mconcat
-        [ declare "The contained integer is smaller than 2^31 = 2147483648" $ isTrue# (i# <# 2147483648#)
+        [ declare "The contained integer is smaller than 2^31 = 2147483648" $ isTrue# (i# <=# 2147483647#)
         , declare "The contained integer is greater than or equal to -2^31 = -2147483648" $ isTrue# (i# >=# -2147483648#)
         ]
 
@@ -453,17 +453,17 @@ instance Validity Word where
 -- | NOT trivially valid on GHC because small number types are represented using a 64bit structure underneath.
 instance Validity Word8 where
     validate (W8# w#) =
-      declare "The contained integer is smaller than 2^8 = 256" $ isTrue# (w# `ltWord#` 256##)
+      declare "The contained integer is smaller than 2^8 = 256" $ isTrue# (w# `leWord#` 255##)
 
 -- | NOT trivially valid on GHC because small number types are represented using a 64bit structure underneath.
 instance Validity Word16 where
     validate (W16# w#) =
-      declare "The contained integer is smaller than 2^16 = 65536" $ isTrue# (w# `ltWord#` 65536##)
+      declare "The contained integer is smaller than 2^16 = 65536" $ isTrue# (w# `leWord#` 65535##)
 
 -- | NOT trivially valid on GHC because small number types are represented using a 64bit structure underneath.
 instance Validity Word32 where
     validate (W32# w#) =
-      declare "The contained integer is smaller than 2^32 = 4294967296" $ isTrue# (w# `ltWord#` 4294967296##)
+      declare "The contained integer is smaller than 2^32 = 4294967296" $ isTrue# (w# `leWord#` 4294967295##)
 
 -- | Trivially valid
 instance Validity Word64 where


### PR DESCRIPTION
The maximum size for e.g. a Word32 is 2^32 - 1. This happens to work OK
on 64 bit CPU architectures, but fails badly on 32 bit.

https://github.com/NorfairKing/validity/issues/84