### PR TITLE
Exclude surrogate and non-characters from being generated

### DIFF
--- a/genvalidity-text/src/Data/GenValidity/Text.hs
+++ b/genvalidity-text/src/Data/GenValidity/Text.hs
@@ -114,8 +114,8 @@ isNoncharacter :: Char -> Bool
 isNoncharacter x =
   (x >= '\64976' && x <= '\65007') || x == '\65534' || x == '\65535'
 
-genValidUtf8 :: Gen ST.Text
-genValidUtf8 = ST.pack <$> genListOf (genValid `suchThat` (\x -> not (isNoncharacter x) && not (isSurrogate x)))
+genValidUnicode :: Gen ST.Text
+genValidUnicode = ST.pack <$> genListOf (genValid `suchThat` (\x -> not (isNoncharacter x) && not (isSurrogate x)))
 
 -- | 'textAllCaps' generates a 'Text' value with only upper-case characters.
 textAllCaps :: Gen ST.Text


### PR DESCRIPTION
Similar to:
https://github.com/hedgehogqa/haskell-hedgehog/pull/154

Follows the documentation to exclude surrogate and non-characters from generating a UTF-8 character:
https://unicodebook.readthedocs.io/unicode_encodings.html#surrogates
http://www.unicode.org/faq/private_use.html#nonchar1