### PR TITLE
Support text-2.0

### DIFF
--- a/genvalidity-text/test/Data/GenValidity/TextSpec.hs
+++ b/genvalidity-text/test/Data/GenValidity/TextSpec.hs
@@ -13,7 +13,6 @@ import qualified Data.Text.Array as A
 import qualified Data.Text.Internal as ST
 import qualified Data.Text.Internal.Lazy as LT
 import qualified Data.Text.Lazy as LT
-import Data.Word
 import Test.Hspec
 import Test.QuickCheck
 import Test.Validity
@@ -25,12 +24,12 @@ showTextDebug (ST.Text arr off len) =
     [ unwords
         [ "arr:   ",
           intercalate "," $
-            map (printf "%4d" :: Word16 -> String) $ A.toList arr off len
+            map (printf "%4d") $ A.toList arr off len
         ],
       unwords
         [ "hexarr:",
           intercalate "," $
-            map (printf "%4x" :: Word16 -> String) $ A.toList arr off len
+            map (printf "%4x") $ A.toList arr off len
         ],
       unwords ["off:      ", show off],
       unwords ["len:      ", show len]

--- a/validity-text/src/Data/Validity/Text.hs
+++ b/validity-text/src/Data/Validity/Text.hs
@@ -20,9 +20,10 @@ instance Validity ST.Text where
   validate t@(ST.Text arr off len) =
     mconcat
       [ check (len >= 0) "The length is positive.",
-        check (off >= 0) "The offset is positive.",
+        check (off >= 0) "The offset is positive."]
 #if MIN_VERSION_text(2,0,0)
-        check
+      ++
+      [ check
           ( let c = A.unsafeIndex arr off
              in len == 0 || c < 0x80 || c >= 0xC0
           )
@@ -41,8 +42,10 @@ instance Validity ST.Text where
                 $ A.toList arr off len
           )
           "The bytes can correctly be decoded as UTF8."
+      ]
 #else
-        check
+      ++
+      [ check
           ( let c = A.unsafeIndex arr off
              in len == 0 || c < 0xDC00 || c > 0xDFFF
           )
@@ -61,8 +64,8 @@ instance Validity ST.Text where
                 $ A.toList arr off len
           )
           "The bytes can correctly be decoded as UTF16."
-#endif
       ]
+#endif
 
 -- | A lazy text value is valid if all the internal chunks are valid and nonempty
 instance Validity LT.Text where


### PR DESCRIPTION
Tested by `stack test genvalidity-text` with 
```yaml
- github: haskell/text
  commit: 922d9cc7c537d55e3be2dba2343ef43e25493ace
- github: haskell/attoparsec
  commit: 8d2765baa343d2160d6b76f60954122c8e384e6d
- github: Bodigrim/aeson
  commit: 471147d990ec95e44cde6057e5846f08bf454041
- hashable-1.4.0.1
- OneTuple-0.3.1
- time-compat-1.9.6.1
- parsec-3.1.15.0
- Cabal-3.2.1.0
- base-orphans-0.8.6
```