### PR TITLE
Add GHC 9.2 support

### DIFF
--- a/genvalidity-aeson/src/Data/GenValidity/Aeson.hs
+++ b/genvalidity-aeson/src/Data/GenValidity/Aeson.hs
@@ -1,8 +1,14 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.GenValidity.Aeson where
 
 import Data.Aeson
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap (KeyMap)
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Key as K
+#endif
 import Data.Foldable (toList)
 import Data.GenValidity
 import Data.GenValidity.HashMap ()
@@ -11,6 +17,16 @@ import Data.GenValidity.Text ()
 import Data.GenValidity.Vector ()
 import Data.Validity.Aeson ()
 import Test.QuickCheck
+
+#if MIN_VERSION_aeson(2,0,0)
+instance GenValid Key where
+  genValid = K.fromString <$> genValid
+  shrinkValid = fmap K.fromString . shrinkValid . K.toString
+
+instance (GenValid v) => GenValid (KeyMap v) where
+  genValid = KM.fromList <$> genValid
+  shrinkValid = fmap KM.fromList . shrinkValid . KM.toList
+#endif
 
 instance GenValid Value where
   genValid =

--- a/shell.nix
+++ b/shell.nix
@@ -8,6 +8,7 @@ pkgs.haskell.lib.buildStackProject {
   buildInputs = with pkgs; [
     (import sources.niv { }).niv
     zlib
+    haskell.compiler.ghc921
   ] ++ pre-commit.tools;
   shellHook = pre-commit.run.shellHook;
 }

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -1,0 +1,81 @@
+resolver: nightly-2022-02-07
+compiler: ghc-9.2.1
+packages:
+- 'genvalidity'
+- 'genvalidity-aeson'
+- 'genvalidity-bytestring'
+- 'genvalidity-containers'
+- 'genvalidity-criterion'
+- 'genvalidity-hspec'
+- 'genvalidity-hspec-aeson'
+- 'genvalidity-hspec-binary'
+- 'genvalidity-hspec-cereal'
+- 'genvalidity-hspec-hashable'
+- 'genvalidity-hspec-optics'
+- 'genvalidity-hspec-persistent'
+- 'genvalidity-path'
+- 'genvalidity-persistent'
+- 'genvalidity-property'
+- 'genvalidity-scientific'
+- 'genvalidity-sydtest'
+- 'genvalidity-sydtest-aeson'
+- 'genvalidity-sydtest-hashable'
+- 'genvalidity-sydtest-lens'
+- 'genvalidity-sydtest-persistent'
+- 'genvalidity-text'
+- 'genvalidity-time'
+- 'genvalidity-unordered-containers'
+- 'genvalidity-uuid'
+- 'genvalidity-vector'
+- 'validity'
+- 'validity-aeson'
+- 'validity-bytestring'
+- 'validity-containers'
+- 'validity-path'
+- 'validity-persistent'
+- 'validity-primitive'
+- 'validity-scientific'
+- 'validity-text'
+- 'validity-time'
+- 'validity-unordered-containers'
+- 'validity-uuid'
+- 'validity-vector'
+
+
+extra-deps:
+- aeson-2.0.3.0
+- base-compat-0.12.1
+- base-compat-batteries-0.12.1
+- yaml-0.11.7.0 # aeson 2
+# https://github.com/yesodweb/persistent/pull/1338
+- github: brandon-leapyear/persistent
+  commit: ef4d8a2a62e833e3600bfb833b4e6afe984a81d6 # chinn/aeson2
+  subdirs:
+    - persistent
+    - persistent-test
+    - persistent-template
+- github: NorfairKing/autodocodec
+  commit: f0cb2ead0985b4394db0627e6befd7ce23c54c22
+  subdirs:
+    - autodocodec
+    - autodocodec-schema
+    - autodocodec-yaml
+- github: NorfairKing/safe-coloured-text
+  commit: 7a3a7751f27ca65a4b7ec6dcad6e0e8c28f1091f
+  subdirs:
+    - safe-coloured-text
+    - safe-coloured-text-terminfo
+- github: NorfairKing/sydtest
+  commit: 0125c6d6d17d44753c793adc8dcaa4284fef2b7d
+  subdirs:
+    - sydtest
+    - sydtest-discover
+
+ghc-options:
+  "$locals": -Wall -Wincomplete-uni-patterns -Wincomplete-record-updates -Wpartial-fields -Widentities -Wredundant-constraints -Wcpp-undef
+
+# To allow newer base-compat (etc.).
+allow-newer: true
+
+nix:
+  shell-file: shell.nix

--- a/stack-9.2.1.yaml
+++ b/stack-9.2.1.yaml
@@ -55,18 +55,18 @@ extra-deps:
     - persistent-test
     - persistent-template
 - github: NorfairKing/autodocodec
-  commit: f0cb2ead0985b4394db0627e6befd7ce23c54c22
+  commit: 42b42a7407f33c6c74fa4e8c84906aebfed28daf
   subdirs:
     - autodocodec
     - autodocodec-schema
     - autodocodec-yaml
 - github: NorfairKing/safe-coloured-text
-  commit: 7a3a7751f27ca65a4b7ec6dcad6e0e8c28f1091f
+  commit: 034f3612525568b422e0c62b52417d77b7cf31c2
   subdirs:
     - safe-coloured-text
     - safe-coloured-text-terminfo
 - github: NorfairKing/sydtest
-  commit: 0125c6d6d17d44753c793adc8dcaa4284fef2b7d
+  commit: 7d2f125b9b9d9e8e36b92a1da83b934f1a17cc53
   subdirs:
     - sydtest
     - sydtest-discover

--- a/validity-aeson/src/Data/Validity/Aeson.hs
+++ b/validity-aeson/src/Data/Validity/Aeson.hs
@@ -5,7 +5,10 @@ module Data.Validity.Aeson where
 
 import Data.Aeson
 #if MIN_VERSION_aeson(2,0,0)
-import Data.Aeson.KeyMap
+import Data.Aeson.KeyMap (KeyMap)
+import Data.Aeson.Key (Key)
+import qualified Data.Aeson.KeyMap as KM
+import qualified Data.Aeson.Key as K
 #endif
 import Data.Aeson.Types
 import Data.Validity
@@ -15,11 +18,11 @@ import Data.Validity.Text ()
 import Data.Validity.Vector ()
 
 #if MIN_VERSION_aeson(2,0,0)
-instance Validity (KeyMap v) where
-  validate m = annotate m "KeyMap"
+instance Validity v => Validity (KeyMap v) where
+  validate m = annotate (KM.toHashMap m) "KeyMap"
 
 instance Validity Key where
-  validate k = annotate k "Key"
+  validate k = annotate (K.toText k) "Key"
 #endif
 
 -- | A 'Value' is valid if the recursive components are valid.

--- a/validity-aeson/src/Data/Validity/Aeson.hs
+++ b/validity-aeson/src/Data/Validity/Aeson.hs
@@ -1,14 +1,26 @@
+{-# LANGUAGE CPP #-}
 {-# OPTIONS_GHC -fno-warn-orphans #-}
 
 module Data.Validity.Aeson where
 
 import Data.Aeson
+#if MIN_VERSION_aeson(2,0,0)
+import Data.Aeson.KeyMap
+#endif
 import Data.Aeson.Types
 import Data.Validity
 import Data.Validity.HashMap ()
 import Data.Validity.Scientific ()
 import Data.Validity.Text ()
 import Data.Validity.Vector ()
+
+#if MIN_VERSION_aeson(2,0,0)
+instance Validity (KeyMap v) where
+  validate m = annotate m "KeyMap"
+
+instance Validity Key where
+  validate k = annotate k "Key"
+#endif
 
 -- | A 'Value' is valid if the recursive components are valid.
 instance Validity Value where

--- a/validity/src/Data/Validity.hs
+++ b/validity/src/Data/Validity.hs
@@ -100,7 +100,11 @@ import Data.Int (Int64)
 import Data.List (intercalate)
 import Data.List.NonEmpty (NonEmpty ((:|)))
 import Data.Maybe (fromMaybe)
+#if MIN_VERSION_base(4,16,0)
+import GHC.Exts (Char (..), isTrue#, ord#, (<=#), (>=#))
+#else
 import GHC.Exts (Char (..), isTrue#, leWord#, ord#, (<=#), (>=#))
+#endif
 import GHC.Generics
 import GHC.Int (Int16 (..), Int32 (..), Int8 (..))
 import GHC.Natural

--- a/validity/src/Data/Validity.hs
+++ b/validity/src/Data/Validity.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DefaultSignatures #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE FlexibleContexts #-}
@@ -433,6 +434,11 @@ isSingleLine = not . any isLineSeparator
 instance Validity Int where
   validate = trivialValidation
 
+#if MIN_VERSION_base(4,16,0)
+instance Validity Int8 where validate = trivialValidation
+instance Validity Int16 where validate = trivialValidation
+instance Validity Int32 where validate = trivialValidation
+#else
 -- | NOT trivially valid on GHC because small number types are represented using a 64bit structure underneath.
 instance Validity Int8 where
   validate (I8# i#) =
@@ -456,6 +462,7 @@ instance Validity Int32 where
       [ declare "The contained integer is smaller than 2^31 = 2147483648" $ isTrue# (i# <=# 2147483647#),
         declare "The contained integer is greater than or equal to -2^31 = -2147483648" $ isTrue# (i# >=# -2147483648#)
       ]
+#endif
 
 -- | Trivially valid
 instance Validity Int64 where
@@ -465,6 +472,11 @@ instance Validity Int64 where
 instance Validity Word where
   validate = trivialValidation
 
+#if MIN_VERSION_base(4,16,0)
+instance Validity Word8 where validate = trivialValidation
+instance Validity Word16 where validate = trivialValidation
+instance Validity Word32 where validate = trivialValidation
+#else
 -- | NOT trivially valid on GHC because small number types are represented using a 64bit structure underneath.
 instance Validity Word8 where
   validate (W8# w#) =
@@ -479,6 +491,7 @@ instance Validity Word16 where
 instance Validity Word32 where
   validate (W32# w#) =
     declare "The contained integer is smaller than 2^32 = 4294967296" $ isTrue# (w# `leWord#` 4294967295##)
+#endif
 
 -- | Trivially valid
 instance Validity Word64 where

--- a/validity/test/Data/ValiditySpec.hs
+++ b/validity/test/Data/ValiditySpec.hs
@@ -1,3 +1,4 @@
+{-# LANGUAGE CPP #-}
 {-# LANGUAGE DeriveGeneric #-}
 {-# LANGUAGE MagicHash #-}
 
@@ -51,30 +52,48 @@ spec = do
     describe "Validity Int8" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Int8) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Int8) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Int# 200 is invalid" $ isValid (I8# 200#) `shouldBe` False
       it "Says that Int# -200 is invalid" $ isValid (I8# (-200#)) `shouldBe` False
+#endif
     describe "Validity Int16" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Int16) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Int16) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Int# 4000 is invalid" $ isValid (I16# 40000#) `shouldBe` False
       it "Says that Int# -4000 is invalid" $ isValid (I16# (-40000#)) `shouldBe` False
+#endif
     describe "Validity Int32" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Int32) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Int32) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Int# 2200000000 is invalid" $ isValid (I32# 2200000000#) `shouldBe` False
       it "Says that Int# -2200000000 is invalid" $ isValid (I32# (-2200000000#)) `shouldBe` False
+#endif
     describe "Validity Word8" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Word8) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Word8) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Word# 300 is invalid" $ isValid (W8# 300##) `shouldBe` False
+#endif
     describe "Validity Word16" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Word16) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Word16) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Word# 80000 is invalid" $ isValid (W16# 80000##) `shouldBe` False
+#endif
     describe "Validity Word32" $ do
       it "Says that minBound is valid" $ isValid (minBound :: Word32) `shouldBe` True
       it "Says that maxBound is valid" $ isValid (maxBound :: Word32) `shouldBe` True
+#if MIN_VERSION_base(4,16,0)
+#else
       it "Says that Word# 4800000000 is invalid" $ isValid (W32# 4800000000##) `shouldBe` False
+#endif
   describe "Chars" $ do
     describe "Small" $ do
       describe "Validity Char" $ do


### PR DESCRIPTION
- Sized Word/Int changes: https://gitlab.haskell.org/ghc/ghc/-/wikis/migration/9.2#sized-wordint-use-sized-wordint-primitives
- Aeson 2's KeyMap/Key types are new: https://github.com/haskell/aeson/issues/881#issuecomment-944920664 (also resolves #99)
- Use https://github.com/yesodweb/persistent/pull/1338