### PR TITLE
validity-text requires validity >= 0.12

### DIFF
--- a/validity-text/package.yaml
+++ b/validity-text/package.yaml
@@ -10,7 +10,7 @@ github: NorfairKing/validity
 
 dependencies:
 - base >=4.7 && <5
-- validity >=0.5
+- validity >=0.12
 - text
 - bytestring
 

--- a/validity-text/validity-text.cabal
+++ b/validity-text/validity-text.cabal
@@ -32,5 +32,5 @@ library
       base >=4.7 && <5
     , bytestring
     , text
-    , validity >=0.5
+    , validity >=0.12
   default-language: Haskell2010


### PR DESCRIPTION
...because `validateStringSingleLine` was not present before. 

As a Hackage trustee I made a revision: https://hackage.haskell.org/package/validity-text-0.3.1.2/revisions/